### PR TITLE
Some fixes for react-docgen-external example

### DIFF
--- a/react-docgen-external-proptypes-handler.js
+++ b/react-docgen-external-proptypes-handler.js
@@ -51,12 +51,16 @@ function amendPropTypes(documentation, path) {
         utils.getPropertyName(propertyPath)
       );
       valuePath = propertyPath.get('value');
-      type = isPropTypesExpression(valuePath)
-        ? utils.getPropType(valuePath)
-        : {
-          name: 'custom',
-          raw: utils.printValue(valuePath)
-        };
+      if (valuePath.value && valuePath.value.type === types.Identifier.name) {
+        type = utils.getPropType(utils.resolveToValue(valuePath.get('value')));
+      } else {
+        type = isPropTypesExpression(valuePath)
+          ? utils.getPropType(valuePath)
+          : {
+              name: 'custom',
+              raw: utils.printValue(valuePath)
+            };
+      }
       if (type) {
         propDescriptor.type = type;
         propDescriptor.required =
@@ -148,7 +152,7 @@ function getIdentifiers(ast) {
   recast.visit(ast, {
     visitVariableDeclarator(path) {
       const node = path.node;
-      const nodeType = node.init.type;
+      const nodeType = (node.init || {}).type;
 
       if (nodeType === types.Identifier.name) {
         if (identifiers[node.init.name]) {


### PR DESCRIPTION
Thanks a lot for sharing this file, I found some enhancements and a small fix I'll share back.
One is just a bug which occurred in some odd situations, the other is for the following situation:

```jsx
import props from './props';
export default class Example extends React.Component {
  static propTypes = props;
}

// ./props
const SomeProp = PropTypes.oneOf(['a', 'b']);
export default {
  exampleProp: SomeProp
};
```

Doesn't yet handle either of these as prop types, later I might figure out how to recurse into those `oneOfType` and `arrayOf` variable declarations.
```jsx
const OptionType = PropTypes.object;
const OptionsType = PropTypes.arrayOf(OptionType);
const ValueType = PropTypes.oneOfType([OptionType, OptionsType]);
```